### PR TITLE
moved check for class definitions into 'init' action, since classes don'...

### DIFF
--- a/voce-theme-customizer.php
+++ b/voce-theme-customizer.php
@@ -9,9 +9,9 @@
  */
 
 // Class can't be defined before WP_Customize_Image_Control
-if ( class_exists( 'WP_Customize_Image_Control' ) && ! class_exists( 'Voce_Customize_Image_Control' ) ) :
-
 add_action( 'init', function() {
+
+	if ( class_exists( 'WP_Customize_Image_Control' ) && ! class_exists( 'Voce_Customize_Image_Control' ) ) :
 
 	class Voce_Customize_Image_Control extends WP_Customize_Image_Control {
 
@@ -126,14 +126,14 @@ add_action( 'init', function() {
 
 	Voce_Customize_Image_Control::init();
 
-}, 11 );
+	endif;
 
-endif;
+} );
 
 // Class can't be defined before WP_Customize_Control
-if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Voce_Customize_Dropdown_Control' ) ) :
+add_action( 'init', function() {
 
-add_action( 'plugins_loaded', function() {
+	if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Voce_Customize_Dropdown_Control' ) ) :
 
 	class Voce_Customize_Dropdown_Control extends WP_Customize_Control {
 
@@ -172,15 +172,14 @@ add_action( 'plugins_loaded', function() {
 		}
 	}
 
-}, 11 );
-
-endif;
+	endif;
+} );
 
 
 // Class can't be defined before WP_Customize_Control
-if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Voce_Customize_Textarea_Control' ) ) :
+add_action( 'init', function() {
 
-add_action( 'plugins_loaded', function() {
+	if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'Voce_Customize_Textarea_Control' ) ) :
 
 	class Voce_Customize_Textarea_Control extends WP_Customize_Control {
 
@@ -201,6 +200,5 @@ add_action( 'plugins_loaded', function() {
 		}
 	}
 
+	endif;
 } );
-
-endif;


### PR DESCRIPTION
...t exist yet when plugin is loaded.
